### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,4 +1,6 @@
 name: 'Flutter: build APK'
+permissions:
+  contents: read
 
 on:
   push:
@@ -27,6 +29,8 @@ jobs:
           path: build/app/outputs/apk/release/app-release.apk
   release:
     name: Release APK
+    permissions:
+      contents: write
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Shaneosaure/app_farmbot/security/code-scanning/3](https://github.com/Shaneosaure/app_farmbot/security/code-scanning/3)

To fix the workflow such that it adheres to the principle of least privilege, you should add a `permissions` block at the root level to grant only read access to `contents` by default, and then add a specific `permissions` block to the `release` job overriding it as needed (since this job creates releases and uploads release assets, it needs `contents: write`). This change will reduce token privileges for jobs that do not need write access, while preserving necessary permissions for jobs that require them.

You need to:
1. Add a root-level `permissions` block:
   ```
   permissions:
     contents: read
   ```
   just after the `name` key in the workflow file.
2. Add a `permissions` block inside the `release` job, specifying:
   ```
     permissions:
       contents: write
   ```
   immediately after `name: Release APK` in that job's definition.

No changes to existing workflow steps are needed, and no additional definitions or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
